### PR TITLE
chore: update `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1624561540,
-        "narHash": "sha256-izJ2PYZMGMsSkg+e7c9A1x3t/yOLT+qzUM6WQsc2tqo=",
+        "lastModified": 1685677062,
+        "narHash": "sha256-zoHF7+HNwNwne2XEomphbdc4Y8tdWT16EUxUTXpOKpQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6a049a3d32293b24c0f894a840872cf67fd7c11",
+        "rev": "95be94370d09f97f6af6a1df1eb9649b5260724e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
nixpkgs-unstable was almost 2 years out of date, which means that the latest Go version available was 1.16.
This meant that I was unable to build your go modules.

```
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c6a049a3d32293b24c0f894a840872cf67fd7c11' (2021-06-24)
  → 'github:NixOS/nixpkgs/95be94370d09f97f6af6a1df1eb9649b5260724e' (2023-06-02)
```