### PR TITLE
feat: add discord-applemusic-rich-presence module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,22 +1,25 @@
 {
   description = "My personal NUR repository";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  outputs = { self, nixpkgs }:
-    let
-      systems = [
-        "x86_64-linux"
-        "i686-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-        "armv6l-linux"
-        "armv7l-linux"
-      ];
-      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-    in
-    {
-      packages = forAllSystems (system: import ./default.nix {
-        pkgs = import nixpkgs { inherit system; };
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    systems = [
+      "x86_64-linux"
+      "i686-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "armv6l-linux"
+      "armv7l-linux"
+    ];
+    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+  in {
+    packages = forAllSystems (system:
+      import ./default.nix {
+        pkgs = import nixpkgs {inherit system;};
       });
-    };
+    homeManagerModules.default = import ./modules/hm;
+  };
 }

--- a/modules/hm/default.nix
+++ b/modules/hm/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./discord-applemusic-rich-presence.nix
+  ];
+}

--- a/modules/hm/discord-applemusic-rich-presence.nix
+++ b/modules/hm/discord-applemusic-rich-presence.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.discord-applemusic-rich-presence;
+  flakePkgs = import ../.. {inherit pkgs;};
+in {
+  options.services.discord-applemusic-rich-presence = {
+    enable = mkEnableOption "discord-applemusic-rich-presence";
+    package = mkPackageOption flakePkgs "discord-applemusic-rich-presence" {};
+    logFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = ''
+        ${config.xdg.cacheHome}/discord-applemusic-rich-presence.log
+      '';
+      description = ''
+        Path to a file to log to. If not specified, no logging will be done.
+      '';
+    };
+  };
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+      launchd.agents.discord-applemusic-rich-presence = {
+        enable = true;
+        config = {
+          ProgramArguments = ["${cfg.package}/bin/discord-applemusic-rich-presence"];
+          KeepAlive = true;
+          RunAtLoad = true;
+          StandardOutPath = cfg.logFile;
+          StandardErrorPath = cfg.logFile;
+        };
+      };
+    })
+  ];
+}


### PR DESCRIPTION
Mainly made this [for myself](https://github.com/nekowinston/dotfiles/commit/47abbffb1b8641dd678fbbbcbf168b97106bed59#diff-532dba090f4ead73a3faecd7105b0867fb67604a69b7aa8f957d0c7db533a503R40-R41) so we can use `services.discord-applemusic-rich-presence.enable = true;` instead of having to resort to manually creating launchd agents. 😄

I've created the module in `./modules/hm/` if you ever want to offer NixOS/Darwin modules later.